### PR TITLE
Fix code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/utils/schema/extractor.ts
+++ b/utils/schema/extractor.ts
@@ -36,8 +36,8 @@ export function getBaseTypeOfList(listType: string) {
 
 function getKeyValuePair(mapType: string) {
   const splitCharacter = ':';
-  mapType = mapType.replace('[', splitCharacter);
-  mapType = mapType.replace(']', splitCharacter);
+  mapType = mapType.replace(/\[/g, splitCharacter);
+  mapType = mapType.replace(/\]/g, splitCharacter);
   return mapType.split(splitCharacter)[1];
 }
 


### PR DESCRIPTION
Fixes [https://github.com/SounakMandal/codegen/security/code-scanning/7](https://github.com/SounakMandal/codegen/security/code-scanning/7)

To fix the problem, we need to ensure that all occurrences of the `]` character in the `mapType` string are replaced. This can be achieved by using a regular expression with the global flag (`g`). This ensures that every instance of the character is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
